### PR TITLE
related products can be clicked to go to product detail of that product

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -15,6 +15,7 @@ class App extends React.Component {
       productList: [],
       currentId: 40344,
     }
+    this.relatedProdClick = this.relatedProdClick.bind(this)
   }
 
   componentDidMount() {
@@ -34,19 +35,21 @@ class App extends React.Component {
     })
   }
 
-
+  relatedProdClick(id, product) {
+    this.setState({currentId: id, currentProduct: product})
+  }
 
   render() {
     return(<div>
       Hi friends!
       npm run react-dev should open a live listener of webpack,
-      then if you refresh the index.html you have open it should update it all!
+      in another terminal do npm run server-dev and navigate to localhost:8000 to view the app!
       <div><ProductDetails
       products={this.state.productList}
       id={this.state.currentId}
       currentProduct={this.state.currentProduct}/></div>
       <div><QAndA productId={this.state.currentId}/></div>
-      <div>{this.state.currentProduct.id ? <RelatedItems products={this.state}/> : null}</div>
+      <div><RelatedItems key={this.state.currentId} products={this.state} onClick={this.relatedProdClick}/></div>
       <div><Reviews/></div>
     </div>
 

--- a/src/components/RelatedItems/RelatedItems.jsx
+++ b/src/components/RelatedItems/RelatedItems.jsx
@@ -9,14 +9,14 @@ class RelatedItems extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      product_id: this.props.products.currentProduct.id,
+      product_id: null
     }
   }
 
 
 
   componentDidMount() {
-    let ID = this.props.products.currentProduct.id
+    let ID = this.props.products.currentId
     var relatedProds = [];
     axios.defaults.headers.common['Authorization'] = config.TOKEN;
     axios.get(`https://app-hrsei-api.herokuapp.com/api/fec2/hr-rfp/products/${ID}/related`, { params: {product_id: ID
@@ -102,13 +102,12 @@ class RelatedItems extends React.Component {
   }
 
 
-
   render() {
     return (
         <div className="related-list" style={
           {display: 'flex', overflow: 'auto', justifyContent: 'center', border: '1px solid blue'}
         }>
-        {this.state.relatedProducts ?  <RelatedList relatedProducts={this.state.relatedProducts}/> : null }
+        {this.state.relatedProducts ?  <RelatedList onClick={this.props.onClick} relatedProducts={this.state.relatedProducts}/> : null }
         </div>
     )
   }

--- a/src/components/RelatedItems/productCard.jsx
+++ b/src/components/RelatedItems/productCard.jsx
@@ -5,8 +5,14 @@ class ProductCard extends React.Component {
     super(props)
     this.state = {
     };
+    this.onProdClick = this.onProdClick.bind(this)
   }
 
+
+  onProdClick(e) {
+    e.preventDefault();
+    this.props.onClick(this.props.product.id, this.props.product)
+  }
 
   render() {
     if (this.props.product.default === undefined) {
@@ -15,7 +21,7 @@ class ProductCard extends React.Component {
       )
     } else {
       return (
-        <div className="card" style={
+        <div  className="card" id={this.props.product.name}  onClick={this.onProdClick} style={
           {display: 'inline-block',
           border: '1px solid blue',
           margin: '10px'}

--- a/src/components/RelatedItems/relatedList.jsx
+++ b/src/components/RelatedItems/relatedList.jsx
@@ -12,7 +12,7 @@ var RelatedList = (props) => {
     whiteSpace: 'nowrap'
    }}
    >{props.relatedProducts.map((product, index) => {
-      return <ProductCard class="card" key= {product.id} product={product}/>
+      return <ProductCard class="card" key= {product.id} product={product} onClick={props.onClick}/>
    })}</div>
   );
 }


### PR DESCRIPTION
Added click functionality to related products card.  Clicking anywhere on the card should load that product as the main product detail and re-render/load the related products list to reflect that of the new main product.

NOTE: This product API we have been given will error and time-out if you try to click through too many products too quickly...do not abuse it or it will break.
