### PR TITLE
css changes to prevent thumbnail wheel shift

### DIFF
--- a/src/components/ProductDetails/ImageGallery.jsx
+++ b/src/components/ProductDetails/ImageGallery.jsx
@@ -130,12 +130,16 @@ class ImageGallery extends React.Component {
 
           <div>
             {/* up arrow, hide if expanded */}
+            <div>
             {!this.state.expanded && this.state.photos.length > 7 && this.state.offset > 0 &&
             <img src={upArrow}
               onClick={this.handleUpClick.bind(this)}
-              className='vertArrow'/>
+              className='vertArrow upArrow'/>
             }
-            {!this.state.expanded && this.state.thumbnails.map((photo, index) => {
+
+            </div>
+            <div className='thumbnailContainer'>
+              {!this.state.expanded && this.state.thumbnails.map((photo, index) => {
               if (index + this.state.offset === this.state.photoIndex) {
                 //return a highlighted component if it is the current photo
                 return(
@@ -155,11 +159,13 @@ class ImageGallery extends React.Component {
                   key={index}/>
               )
             })}
+            </div>
+
             {/* down arrow, hide on expand */}
             {!this.state.expanded && this.state.photos?.length > 7 && this.state.offset + 7 < this.state.photos?.length &&
               <img src={downArrow}
               onClick={this.handleDownClick.bind(this)}
-              className='vertArrow'
+              className='vertArrow downArrow'
             />}
           </div>
           {/* left arrow, hide arrow if on first image, hide on expand */}

--- a/src/components/ProductDetails/styles/ProductDetails.css
+++ b/src/components/ProductDetails/styles/ProductDetails.css
@@ -38,6 +38,13 @@ div {
   height: 100%;
 }
 
+.thumbnailContainer {
+  position: absolute;
+  top: 5%;
+  height: 80%;
+  max-height: 80%;
+}
+
 .imageContainer {
   display: flex;
   justify-content: center;
@@ -59,11 +66,22 @@ div {
   width: 3%;
   height: 3%;
   display: flex;
-  left: .75%;
+  left: 2%;
   z-index: 3;
   position: relative;
   object-fit: contain;
-  opacity: 0.7;
+}
+
+.upArrow {
+  position: absolute;
+  top: 0%;
+  left: 3%;
+}
+
+.downArrow {
+  position: absolute;
+  bottom: 0%;
+  left: 3%;
 }
 
 .expandedUp {


### PR DESCRIPTION
changed arrow positioning to no longer move the whole thumbnail wheel when the top arrow is rendered